### PR TITLE
Fixes: Returning 403 from non-auth messages would trigger retrying login, even for non-authed users

### DIFF
--- a/ObjectiveDDP/MeteorClient+Parsing.m
+++ b/ObjectiveDDP/MeteorClient+Parsing.m
@@ -45,7 +45,8 @@ static int LOGON_RETRY_MAX = 5;
     if([msg isEqualToString:@"result"]
        && message[@"error"]
        && [message[@"error"][@"error"] integerValue] == 403
-       && self.authState != AuthStateLoggedOut) {
+       && self.authState != AuthStateLoggedOut
+       && self.authState != AuthStateNoAuth) {
         [self _setAuthStatetoLoggedOut];
         if (++_retryAttempts < LOGON_RETRY_MAX && self.connected) {
             [self logonWithUserParameters:_logonParams username:_userName password:_password responseCallback:_logonMethodCallback];


### PR DESCRIPTION
This would result in a crash if no username was set.  In this case, if
the session has not initiated a login (AuthStateNoAuth) it will not try
to login again.
