### PR TITLE
Use NSUTF8StringEncoding in Auth sha256

### DIFF
--- a/ObjectiveDDP/MeteorClient.m
+++ b/ObjectiveDDP/MeteorClient.m
@@ -150,7 +150,7 @@ NSString * const MeteorClientTransportErrorDomain = @"boundsj.objectiveddp.trans
 
 // move this to string category
 - (NSString *)sha256:(NSString *)clear {
-    const char *s = [clear cStringUsingEncoding:NSASCIIStringEncoding];
+    const char *s = [clear cStringUsingEncoding:NSUTF8StringEncoding];
     NSData *keyData = [NSData dataWithBytes:s length:strlen(s)];
     
     uint8_t digest[CC_SHA256_DIGEST_LENGTH] = {0};


### PR DESCRIPTION
With NSASCIIStringEncoding, it was not possible to accept non-ascii characters in the password (éàû etc..)
