### PR TITLE
Method for custom parameters in signup

### DIFF
--- a/ObjectiveDDP/MeteorClient.h
+++ b/ObjectiveDDP/MeteorClient.h
@@ -56,6 +56,9 @@ typedef void(^MeteorClientMethodCallback)(NSDictionary *response, NSError *error
 - (void)logonWithUserParameters:(NSDictionary *)userParameters responseCallback:(MeteorClientMethodCallback)responseCallback;
 
 - (void)signupWithUsernameAndEmail:(NSString *)username email:(NSString *)email password:(NSString *)password fullname:(NSString *)fullname responseCallback:(MeteorClientMethodCallback)responseCallback;
+
+- (void)signupWithUsernameAndEmail:(NSString *)username email:(NSString *)email password:(NSString *)password userParameters:(NSDictionary *)userParameters responseCallback:(MeteorClientMethodCallback)responseCallback;
+
 - (void)signupWithUsername:(NSString *)username password:(NSString *)password fullname:(NSString *)fullname responseCallback:(MeteorClientMethodCallback)responseCallback;
 - (void)signupWithEmail:(NSString *)email password:(NSString *)password fullname:(NSString *)fullname responseCallback:(MeteorClientMethodCallback)responseCallback;
 - (void)signupWithEmail:(NSString *)email password:(NSString *)password firstName:(NSString *)firstName lastName:(NSString *)lastName responseCallback:(MeteorClientMethodCallback)responseCallback;

--- a/ObjectiveDDP/MeteorClient.m
+++ b/ObjectiveDDP/MeteorClient.m
@@ -205,6 +205,12 @@ double const MeteorClientMaxRetryIncrease = 6;
     [self signupWithUserParameters:[self _buildUserParametersSignup:username email:email password:password fullname:fullname] responseCallback:responseCallback];
 }
 
+- (void)signupWithUsernameAndEmail:(NSString *)username email:(NSString *)email password:(NSString *)password userParameters:(NSDictionary *)userParameters responseCallback:(MeteorClientMethodCallback)responseCallback{
+    NSMutableDictionary *parameters = [[self _buildUserParametersSignup:username email:email password:password] mutableCopy];
+    [parameters addEntriesFromDictionary:userParameters];
+    [self signupWithUserParameters:parameters responseCallback:responseCallback];
+}
+
 - (void)signupWithUsername:(NSString *)username password:(NSString *)password fullname:(NSString *)fullname responseCallback:(MeteorClientMethodCallback)responseCallback {
     [self signupWithUserParameters:[self _buildUserParametersSignup:username email:@"" password:password fullname:fullname] responseCallback:responseCallback];
 }
@@ -475,6 +481,13 @@ double const MeteorClientMaxRetryIncrease = 6;
                              @"last_name": lastName,
                              @"signupToken": @""
                              } };
+}
+
+- (NSDictionary *)_buildUserParametersSignup:(NSString *)username email:(NSString *)email password:(NSString *)password
+{
+    return @{ @"username": username,@"email": email,
+              @"password": @{ @"digest": [self sha256:password], @"algorithm": @"sha-256" }
+            };
 }
 
 - (NSDictionary *)_buildUserParametersWithUsername:(NSString *)username password:(NSString *)password


### PR DESCRIPTION
I've added a new method to meteor client that allows using username, email, password and custom fields. I'm already using it in my fork and works as expected, would be great if it could be integrated in main ObjectiveDDP.