### PR TITLE
Fixed EXC_BAD_ACCESS error on reconnection

### DIFF
--- a/ObjectiveDDP/ObjectiveDDP.m
+++ b/ObjectiveDDP/ObjectiveDDP.m
@@ -105,6 +105,7 @@
 
 - (void)_closeConnection {
     [self.webSocket close];
+    self.webSocket.delegate = nil;
     self.webSocket = nil;
 }
 


### PR DESCRIPTION
if _closeConnection is called while SocketRocket is still in the process of handling a stream, it will try to access a delegate that no longer exists, causing a EXC_BAD_ACCESS error.

Explicitly nullifying the delegate after closing the web socket appears to resolve this issue.