### PR TITLE
Improvement for prevent calling wrong init method

### DIFF
--- a/ObjectiveDDP.podspec
+++ b/ObjectiveDDP.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name           = 'ObjectiveDDP'
   s.ios.deployment_target = '7.1'
   s.osx.deployment_target = '10.7'
-  s.version        = '0.1.9'
+  s.version        = '0.2.0'
   s.license        = 'MIT'
   s.summary        = 'Facilitates communication between iOS clients and meteor.js servers'
   s.homepage       = 'https://github.com/boundsj/ObjectiveDDP.git'

--- a/ObjectiveDDP/MeteorClient.h
+++ b/ObjectiveDDP/MeteorClient.h
@@ -45,6 +45,10 @@ typedef void(^MeteorClientMethodCallback)(NSDictionary *response, NSError *error
 //          use "1" for meteor versions v0.8.9 and above
 - (id)initWithDDPVersion:(NSString *)ddpVersion;
 
+// Prevent user from start with this methods
+- (id)init __attribute__((unavailable("Must use initWithDDPVersion: instead.")));
++ (instancetype)new __attribute__((unavailable("Must use initWithDDPVersion: instead.")));
+
 #pragma mark - Methods
 
 - (void) logonWithSessionToken:(NSString *) sessionToken responseCallback:(MeteorClientMethodCallback)responseCallback;

--- a/ObjectiveDDP/MeteorClient.m
+++ b/ObjectiveDDP/MeteorClient.m
@@ -20,11 +20,6 @@ double const MeteorClientMaxRetryIncrease = 6;
 
 @implementation MeteorClient
 
-- (id)init {
-    [self doesNotRecognizeSelector:_cmd];
-    return nil;
-}
-
 - (id)initWithDDPVersion:(NSString *)ddpVersion {
     self = [super init];
     if (self) {

--- a/ObjectiveDDP/ObjectiveDDP.h
+++ b/ObjectiveDDP/ObjectiveDDP.h
@@ -13,6 +13,10 @@
 - (void)ping:(NSString *)id;
 - (void)pong:(NSString *)id;
 
+// Prevent user from start with this methods
+- (id)init __attribute__((unavailable("Must use initWithURLString:delegate: instead.")));
++ (instancetype)new __attribute__((unavailable("Must use initWithURLString:delegate: instead.")));
+
 - (id)initWithURLString:(NSString *)urlString delegate:(id <ObjectiveDDPDelegate>)delegate;
 - (void)connectWebSocket;
 - (void)disconnectWebSocket;


### PR DESCRIPTION
With this improvements we garante that user will use right init method,
prevent from calling “init” and “new” way, and better, when he trie
using these we show message saying which one need be used.